### PR TITLE
Set language in tab

### DIFF
--- a/app/components/language-option.vue
+++ b/app/components/language-option.vue
@@ -3,8 +3,7 @@
     <img 
       :src="flagIcon" 
       alt="flag icon" 
-      class="flag-icon"
-      :class="{ 'large-icon': clicked, 'small-icon': !clicked }" />
+      class="flag-icon" />
   </span>
 </template>
 
@@ -18,33 +17,15 @@
       language: Object
     },
 
-    data() {
-      return {
-        clicked: false
-      }
-    },
-
     computed: {
       flagIcon () {
         return this.language.image
-      },
-      languageSelected () {
-        return this.language.value === this.$store.state.language
       }
     },
 
     methods: {
-      async changeLanguage () {
-        await this.$store.commit('SET_LANGUAGE', this.language.value)
-        this.resizeIcon()
-      },
-      resizeIcon () {
-        this.clicked = !this.clicked
-      },
-      iconStyles () {
-        console.log('lang value: ', this.language.value)
-        console.log('store lang: ', this.$store.state.language)
-        console.log(this.languageSelected)
+      changeLanguage () {
+        this.$store.commit('SET_LANGUAGE', this.language.value)
       }
     }
   }
@@ -53,14 +34,6 @@
 <style>
   .flag-icon {
     margin-bottom: 20px;
-  }
-
-  .large-icon {
-    height: 50px;
-    width: auto;
-  }
-
-  .small-icon {
     height: 30px;
     width: auto;
   }

--- a/app/components/language-option.vue
+++ b/app/components/language-option.vue
@@ -1,9 +1,11 @@
 <template>
-  <span>
-    <button @click="changeLanguage">
-    {{ language.key }}
-    </button>
-  </span>  
+  <span @click="changeLanguage">
+    <img 
+      :src="flagIcon" 
+      alt="flag icon" 
+      class="flag-icon"
+      :class="{ 'large-icon': clicked, 'small-icon': !clicked }" />
+  </span>
 </template>
 
 <script>
@@ -16,11 +18,51 @@
       language: Object
     },
 
+    data() {
+      return {
+        clicked: false
+      }
+    },
+
+    computed: {
+      flagIcon () {
+        return this.language.image
+      },
+      languageSelected () {
+        return this.language.value === this.$store.state.language
+      }
+    },
+
     methods: {
-      changeLanguage (e) {
-        this.$store.commit('SET_LANGUAGE', this.language.value)
+      async changeLanguage () {
+        await this.$store.commit('SET_LANGUAGE', this.language.value)
+        this.resizeIcon()
+      },
+      resizeIcon () {
+        this.clicked = !this.clicked
+      },
+      iconStyles () {
+        console.log('lang value: ', this.language.value)
+        console.log('store lang: ', this.$store.state.language)
+        console.log(this.languageSelected)
       }
     }
   }
 </script>
+
+<style>
+  .flag-icon {
+    margin-bottom: 20px;
+  }
+
+  .large-icon {
+    height: 50px;
+    width: auto;
+  }
+
+  .small-icon {
+    height: 30px;
+    width: auto;
+  }
+</style>
 

--- a/app/components/language-option.vue
+++ b/app/components/language-option.vue
@@ -1,0 +1,26 @@
+<template>
+  <span>
+    <button @click="changeLanguage">
+    {{ language.key }}
+    </button>
+  </span>  
+</template>
+
+<script>
+  import { mapState } from 'vuex'
+
+  export default {
+    name: 'playback',
+
+    props: {
+      language: Object
+    },
+
+    methods: {
+      changeLanguage (e) {
+        this.$store.commit('SET_LANGUAGE', this.language.value)
+      }
+    }
+  }
+</script>
+

--- a/app/components/language-option.vue
+++ b/app/components/language-option.vue
@@ -1,5 +1,5 @@
 <template>
-  <span @click="changeLanguage">
+  <span @click="setLanguage">
     <img 
       :src="flagIcon" 
       alt="flag icon" 
@@ -8,10 +8,10 @@
 </template>
 
 <script>
-  import { mapState } from 'vuex'
+  import { mapState, mapMutations } from 'vuex'
 
   export default {
-    name: 'playback',
+    name: 'language-option',
 
     props: {
       language: Object
@@ -24,7 +24,7 @@
     },
 
     methods: {
-      changeLanguage () {
+      setLanguage () {
         this.$store.commit('SET_LANGUAGE', this.language.value)
       }
     }

--- a/app/components/language-option.vue
+++ b/app/components/language-option.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script>
+  import store from '../store/index.js'
   import { mapState, mapMutations } from 'vuex'
 
   export default {
@@ -25,7 +26,7 @@
 
     methods: {
       setLanguage () {
-        this.$store.commit('SET_LANGUAGE', this.language.value)
+        store.commit('SET_LANGUAGE', this.language.value)
       }
     }
   }

--- a/app/components/tab.vue
+++ b/app/components/tab.vue
@@ -1,9 +1,13 @@
 <template>
   <div>
     <h1 class="page-title">FotoFluent</h1>
+
     <div class="flag-icon" v-if="translation && translation.language">
       <img :src="flagIcon" alt="flag icon" />
     </div>
+    
+    <LanguageOption v-for="lang in languages" :language="lang" key="lang" />
+
     <SearchBox />
     <Translation />
     <TopSites />
@@ -14,6 +18,8 @@
   import Translation from './translation.vue'
   import SearchBox from './search-box.vue'
   import TopSites from './top-sites.vue'
+  import LanguageOption from './language-option.vue'
+  import { LANGUAGES } from '../store/index.js'
   import { mapActions, mapState } from 'vuex'
 
   export default {
@@ -22,11 +28,18 @@
       Translation,
       SearchBox,
       TopSites,
+      LanguageOption
     },
 
     mounted () {
-      this.requestData()
+      // this.requestData()
       this.requestTopSites()
+    },
+
+    data () {
+      return {
+        languages: LANGUAGES
+      }
     },
 
     methods: {

--- a/app/components/tab.vue
+++ b/app/components/tab.vue
@@ -1,13 +1,7 @@
 <template>
   <div>
     <h1 class="page-title">FotoFluent</h1>
-
-    <div class="flag-icon" v-if="translation && translation.language">
-      <img :src="flagIcon" alt="flag icon" />
-    </div>
-    
     <LanguageOption v-for="lang in languages" :language="lang" key="lang" />
-
     <SearchBox />
     <Translation />
     <TopSites />
@@ -74,14 +68,5 @@
   .translation {
     font-size: 48px;
     text-align: center;
-  }
-
-  .flag-icon {
-    margin: 5px 0 10px 0;
-  }
-
-  .flag-icon > img {
-    height: 60px;
-    width: auto;
   }
 </style>

--- a/app/components/tab.vue
+++ b/app/components/tab.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1 class="page-title">FotoFluent</h1>
-    <LanguageOption v-for="lang in languages" :language="lang" key="lang" />
+    <LanguageOption v-for="lang in languages" :language="lang" :key="lang.key" />
     <SearchBox />
     <Translation />
     <TopSites />
@@ -26,7 +26,6 @@
     },
 
     mounted () {
-      // this.requestData()
       this.requestTopSites()
     },
 
@@ -38,7 +37,6 @@
 
     methods: {
       ...mapActions({ 
-        requestData: 'REQUEST_DATA',
         requestTopSites: 'REQUEST_TOP_SITES',
       })
     },

--- a/app/components/translation.vue
+++ b/app/components/translation.vue
@@ -7,11 +7,14 @@
         <span v-if="!showTranslation">Show Translation</span>
         <span v-else>Hide Translation</span>
       </button>
+
       <Playback />
+
       <p v-if="showTranslation">
         {{ translation.word.word }}
       </p>
     </div>
+    
     <div v-else>
       <p>Loading...</p>
     </div>

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -11,22 +11,22 @@ export const LANGUAGES = [
   {
     key: 'GERMAN',
     value: 'de-DE',
-    image: 'https://fotofluent-admin.s3.amazonaws.com/uploads/language/flag/5/germany.png'
+    image: 'https://s3.amazonaws.com/fotofluent/germany.png'
   },
   {
     key: 'SPANISH',
     value: 'es-ES',
-    image: 'https://fotofluent-admin.s3.amazonaws.com/uploads/language/flag/6/spain.png'
+    image: 'https://s3.amazonaws.com/fotofluent/spain.png'
   },
   {
     key: 'ITALIAN',
     value: 'it-IT',
-    image: 'https://fotofluent-admin.s3.amazonaws.com/uploads/language/flag/7/italy.png'
+    image: 'https://s3.amazonaws.com/fotofluent/italy.png'
   },
   {
     key: 'FRENCH',
     value: 'fr-FR',
-    image: 'https://fotofluent-admin.s3.amazonaws.com/uploads/language/flag/8/france.png'
+    image: 'https://s3.amazonaws.com/fotofluent/france.png'
   },
 ]
 

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -8,10 +8,26 @@ Vue.use(Vuex)
 const chromep = new ChromePromise()
 
 export const LANGUAGES = [
-  { key: 'GERMAN', value: 'de-DE' },
-  { key: 'SPANISH', value: 'es-ES' },
-  { key: 'ITALIAN', value: 'it-IT' },
-  { key: 'FRENCH', value: 'fr-FR' },
+  {
+    key: 'GERMAN',
+    value: 'de-DE',
+    image: 'https://fotofluent-admin.s3.amazonaws.com/uploads/language/flag/5/germany.png'
+  },
+  {
+    key: 'SPANISH',
+    value: 'es-ES',
+    image: 'https://fotofluent-admin.s3.amazonaws.com/uploads/language/flag/6/spain.png'
+  },
+  {
+    key: 'ITALIAN',
+    value: 'it-IT',
+    image: 'https://fotofluent-admin.s3.amazonaws.com/uploads/language/flag/7/italy.png'
+  },
+  {
+    key: 'FRENCH',
+    value: 'fr-FR',
+    image: 'https://fotofluent-admin.s3.amazonaws.com/uploads/language/flag/8/france.png'
+  },
 ]
 
 const TRANSLATIONS_ENDPOINT = 'https://fotofluent-admin.herokuapp.com/translations.json'
@@ -20,23 +36,21 @@ const store = new Vuex.Store({
   state: {
     language: 'de-DE',
     topSites: [],
-    translation: {},
+    translation: {}
   },
 
   actions: {
     async HYDRATE_STATE ({ commit, dispatch }) {
-      console.log(`action: calling hydrate state`)
       const items = await chromep.storage.local.get([
         'language',
         'topSites',
         'translation',
       ])
-      commit('SET_LANGUAGE', items.language)
+      commit('SET_LANGUAGE', items.language || store.state.language)
       commit('SET_TOP_SITES', items.topSites)
       await dispatch('REQUEST_DATA')
     },
     async REQUEST_DATA ({ commit }) {
-      console.log(`action: requesting data with ${store.state.language}`)
       try {
         const response = await axios.get(`${TRANSLATIONS_ENDPOINT}?lang=${store.state.language}`)
         const translation = sample(response.data)
@@ -47,7 +61,6 @@ const store = new Vuex.Store({
       }
     },
     async REQUEST_TOP_SITES ({ commit }) {
-      console.log(`action: requesting top sites`)
       const mostVisitedUrls = await chromep.topSites.get()
       commit('SET_TOP_SITES', mostVisitedUrls.slice(0, 5))
     },
@@ -55,17 +68,14 @@ const store = new Vuex.Store({
 
   mutations: {
     SET_LANGUAGE (state, language) {
-      console.log(`mutation: setting language to ${language}`)
       state.language = language
       chromep.storage.local.set({ language })
     },
     SET_TOP_SITES (state, topSites) {
-      console.log(`mutation: setting top sites`)
       state.topSites = topSites
       chromep.storage.local.set({ topSites })
     },
     SET_TRANSLATION (state, translation) {
-      console.log('mutation: setting translation', translation)
       state.translation = translation
     },
   },
@@ -90,9 +100,7 @@ hydrate()
 // Hydrate whenever chrome state changes
 //
 const bindListeners = async () => {
-  console.log(`bindingListeners called`)
   chrome.storage.onChanged.addListener(() => {
-    console.log(`state was updated, will call action to hydrate`)
     store.dispatch('HYDRATE_STATE')
   })
 }

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -36,7 +36,7 @@ const store = new Vuex.Store({
   state: {
     language: 'de-DE',
     topSites: [],
-    translation: {}
+    translation: {},
   },
 
   actions: {

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -91,7 +91,6 @@ const store = new Vuex.Store({
 const hydrate = async () => {
   await store.dispatch('HYDRATE_STATE')
   await bindListeners()
-  await store.dispatch('REQUEST_DATA')
 }
 hydrate()
 

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -89,7 +89,6 @@ const store = new Vuex.Store({
 // Hydrate on app start.
 //
 const hydrate = async () => {
-  console.log(`app start: initial hydrate`)
   await store.dispatch('HYDRATE_STATE')
   await bindListeners()
   await store.dispatch('REQUEST_DATA')


### PR DESCRIPTION
What if we set the language in the tab instead?
- adds small flag icons under FotoFluent title
- changes language on flag click, resets the translations for that new language

note: added the OR condition back to the store hydrate action, since when you first install the extension, the local storage 'language' will be null)